### PR TITLE
Improve README for Minesweeper app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# Minesweeper
+# Minesweeper Edgelord
+
+A Jetpack Compose implementation of Minesweeper with multiple grid types and optional edge wrapping.
+
+## Prerequisites
+
+- Android Studio Hedgehog or newer, **or** a command-line setup with the Android SDK.
+- JDK 8+ (the project targets Java 8) and Kotlin 1.9.23.
+- No separate Gradle installation is required; the project ships with the Gradle wrapper.
+
+## Build and Run
+
+Use the Gradle wrapper to build the debug APK:
+
+```bash
+./gradlew assembleDebug
+```
+
+Install it on a connected device or emulator:
+
+```bash
+./gradlew installDebug
+```
+
+You can also open the project in Android Studio and run it directly from the IDE.
+
+## Features
+
+- Classic reveal/flag/question gameplay.
+- Several board layouts: Square, Triangle, Hexagon, Octasquare, Cairo, Rhombille, Snub Square and Penrose.
+- Configurable edge wrapping (left/right, top/bottom or full torus).
+- Gesture-based controls with zoom and pan support.
+
+### Selecting a Grid Type
+
+Open the Settings screen and pick one of the available tilings. Wrapping options can be toggled per edge. Penrose grids do not support wrapping.


### PR DESCRIPTION
## Summary
- rewrite README with a short project description
- document prerequisites like Android Studio and JDK/Kotlin versions
- add build and run instructions using the Gradle wrapper
- outline features and how to choose grid types

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e771f14e08324b1dcd0d2b4ce3018