### PR TITLE
Fix mapping bug in GameEngine

### DIFF
--- a/app/src/main/java/com/edgefield/minesweeper/GameEngine.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameEngine.kt
@@ -60,7 +60,7 @@ class GameEngine(private val config: GameConfig) {
             val c = Random.nextInt(config.cols)
             val t = board[r][c]
             if (!t.hasMine) {
-                board[r][c] = t.copy(hasMine = true)
+                t.hasMine = true
                 placed++
             }
         }
@@ -98,7 +98,7 @@ class GameEngine(private val config: GameConfig) {
     private fun ensureSafeFirstClick(firstTile: Tile) {
         if (firstTile.hasMine) {
             // Move the mine to a different location
-            board[firstTile.y][firstTile.x] = firstTile.copy(hasMine = false)
+            firstTile.hasMine = false
             
             // Find a new location for the mine
             var placed = false
@@ -107,7 +107,7 @@ class GameEngine(private val config: GameConfig) {
                 val c = Random.nextInt(config.cols)
                 val candidate = board[r][c]
                 if (!candidate.hasMine && candidate != firstTile) {
-                    board[r][c] = candidate.copy(hasMine = true)
+                    candidate.hasMine = true
                     placed = true
                 }
             }


### PR DESCRIPTION
## Summary
- keep tile references stable during mine placement and first click checks

## Testing
- `gradle tasks --all` *(fails: plugin resolution requires network access)*

------
https://chatgpt.com/codex/tasks/task_e_687e76203ecc83248a1fa7735deea44f