### PR TITLE
Fix grid size calculation for non-square boards

### DIFF
--- a/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
@@ -129,7 +129,7 @@ private fun GameBoard(vm: GameViewModel, tileSize: androidx.compose.ui.unit.Dp) 
     val config = vm.gameConfig
     val density = LocalDensity.current.density
     val tileSizePx = tileSize.value * density
-    
+
     // Create tiling using GridSystem
     val tiling = remember(config.gridType, config.cols, config.rows) {
         GridFactory.build(
@@ -147,8 +147,8 @@ private fun GameBoard(vm: GameViewModel, tileSize: androidx.compose.ui.unit.Dp) 
             h = config.rows
         )
     }
-    
-    val renderer = remember(tileSizePx) { TilingRenderer(tileSizePx) }
+    val bounds = remember(tiling) { tiling.modelBounds() }
+    val renderer = remember(tileSizePx, bounds) { TilingRenderer(tileSizePx, bounds) }
     
     // Map tiles to faces (same order as GameEngine)
     val tileToFace = remember(tiling, vm.board) {
@@ -164,8 +164,8 @@ private fun GameBoard(vm: GameViewModel, tileSize: androidx.compose.ui.unit.Dp) 
     Box(
         modifier = Modifier
             .size(
-                width = tileSize * config.cols,
-                height = tileSize * config.rows
+                width = (renderer.width / density).dp,
+                height = (renderer.height / density).dp
             )
     ) {
         val coroutineScope = rememberCoroutineScope()


### PR DESCRIPTION
## Summary
- use GridSystem bounds when rendering tilings
- translate renderer to origin and expose width/height
- adjust GameBoard to size box using renderer bounds

## Testing
- `gradle build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e92f8f9cc832495cc8eb043bff8ff