### PR TITLE
Fix hex grid spacing

### DIFF
--- a/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
@@ -279,9 +279,9 @@ private fun getFaceCentroid(face: Face, renderer: TilingRenderer): Offset {
     
     var e = face.any
     do {
-        val vertex = e.origin
-        sumX += (vertex.modelX * renderer.size).toFloat()
-        sumY += (vertex.modelY * renderer.size).toFloat()
+        val pt = renderer.modelToOffset(e.origin)
+        sumX += pt.x
+        sumY += pt.y
         count++
         e = e.next
     } while (e !== face.any)
@@ -339,15 +339,13 @@ private fun DrawScope.drawGameBoardWithGridSystem(
             var first = true
             
             do {
-                val vertex = e.origin
-                val x = (vertex.modelX * renderer.size).toFloat()
-                val y = (vertex.modelY * renderer.size).toFloat()
-                
+                val pt = renderer.modelToOffset(e.origin)
+
                 if (first) {
-                    path.moveTo(x, y)
+                    path.moveTo(pt.x, pt.y)
                     first = false
                 } else {
-                    path.lineTo(x, y)
+                    path.lineTo(pt.x, pt.y)
                 }
                 e = e.next
             } while (e !== face.any)

--- a/app/src/main/java/com/edgefield/minesweeper/GridSystem.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GridSystem.kt
@@ -17,6 +17,7 @@ import android.graphics.Canvas
 import android.graphics.Path
 import android.graphics.Paint
 import android.graphics.PointF
+import androidx.compose.ui.geometry.Offset
 import kotlin.math.*
 
 //──────────────────────────────────────────────────────────────────────────────
@@ -312,6 +313,9 @@ class TilingRenderer(val size: Float, bounds: Bounds) {
 
     private fun modelToPixel(v: Vertex): PointF =
         PointF(((v.modelX + offsetX)*size).toFloat(), ((v.modelY + offsetY)*size).toFloat())
+
+    fun modelToOffset(v: Vertex): Offset =
+        Offset(((v.modelX + offsetX)*size).toFloat(), ((v.modelY + offsetY)*size).toFloat())
 
     fun facePath(face: Face): Path {
         val p = Path()


### PR DESCRIPTION
## Summary
- expose model-to-pixel conversion for Compose
- use new helper when drawing tiles

## Testing
- `gradle assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e9a97349883248f8a42c6e6580cad