### PR TITLE
Fix vertical spacing in triangle grid

### DIFF
--- a/app/src/main/java/com/edgefield/minesweeper/GridSystem.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GridSystem.kt
@@ -226,19 +226,21 @@ class TriangleGridBuilder(
             for (i in 0 until cols) {
                 val up = (i + j) % 2 == 0
                 if (up) {
-                    // upright Δ
-                    val v0 = tiling.getVertex(i*0.5, j*SQRT3)
-                    val v1 = tiling.getVertex((i+1)*0.5, j*SQRT3)
+                    // upright Δ - use consistent vertical spacing
+                    val baseY = j*SQRT3/2
+                    val v0 = tiling.getVertex(i*0.5, baseY)
+                    val v1 = tiling.getVertex((i+1)*0.5, baseY)
                     val v2 = tiling.getVertex(i*0.5 + 0.25, (j+1)*SQRT3/2)
 
                     val e0 = he(v0); val e1 = he(v1); val e2 = he(v2)
                     connectTwin(v0,v1,e0); connectTwin(v1,v2,e1); connectTwin(v2,v0,e2)
                     registerFace(arrayOf(e0,e1,e2))
                 } else {
-                    // inverted ∇ – shift half height
-                    val v0 = tiling.getVertex(i*0.5 + 0.25, j*SQRT3/2)
-                    val v1 = tiling.getVertex((i+1)*0.5 + 0.25, j*SQRT3/2)
-                    val v2 = tiling.getVertex((i+1)*0.5, j*SQRT3)
+                    // inverted ∇ – shift half height, same vertical scaling
+                    val baseY = j*SQRT3/2
+                    val v0 = tiling.getVertex(i*0.5 + 0.25, (j+1)*SQRT3/2)
+                    val v1 = tiling.getVertex((i+1)*0.5 + 0.25, (j+1)*SQRT3/2)
+                    val v2 = tiling.getVertex((i+1)*0.5, baseY)
 
                     val e0 = he(v0); val e1 = he(v1); val e2 = he(v2)
                     connectTwin(v0,v1,e0); connectTwin(v1,v2,e1); connectTwin(v2,v0,e2)


### PR DESCRIPTION
## Summary
- correct the vertical scaling calculations for upright and inverted triangles in `TriangleGridBuilder`

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e9ad3fda48324b61aa08563ba1da9