### PR TITLE
Fix board controls after restart

### DIFF
--- a/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
@@ -176,7 +176,7 @@ private fun GameBoard(vm: GameViewModel, tileSize: androidx.compose.ui.unit.Dp) 
         Canvas(
             modifier = Modifier
                 .fillMaxSize()
-                .pointerInput(config.touchConfig, waitingForTriple) {
+                .pointerInput(config.touchConfig, waitingForTriple, vm.board) {
                     detectTapGestures(
                         onTap = { offset ->
                             val tile = getTileFromGridSystem(offset, tiling, tileToFace, renderer)


### PR DESCRIPTION
## Summary
- ensure pointer input recomposes when board resets

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e9cd258b08324a3d7f869a9cb4d94