### PR TITLE
Fix hex and triangle grid layout

### DIFF
--- a/app/src/main/java/com/edgefield/minesweeper/GridSystem.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GridSystem.kt
@@ -198,8 +198,9 @@ class HexGridBuilder(
                 val cy = SQRT3 * (r + q/2.0)
 
                 // 6 corners, 0° first → counter‑clockwise
+                // Use a global orientation so adjacent cells share vertices
                 val corners = (0 until 6).map { k ->
-                    val angle = Math.toRadians(60.0*k - 30.0) // flat‑topped
+                    val angle = Math.toRadians(60.0*k) // flat‑topped
                     tiling.getVertex(cx + cos(angle), cy + sin(angle))
                 }.toTypedArray()
 
@@ -225,22 +226,24 @@ class TriangleGridBuilder(
     override fun build(): Tiling {
         for (j in 0 until rows) {
             val baseY = j * SQRT3 / 2
+            val xOff = 0.5 * (j % 2)
             for (i in 0 until cols) {
+                val x = i + xOff
                 val up = (i + j) % 2 == 0
                 if (up) {
                     // Upright Δ with unit edge length
-                    val v0 = tiling.getVertex(i.toDouble(), baseY)
-                    val v1 = tiling.getVertex(i + 1.0, baseY)
-                    val v2 = tiling.getVertex(i + 0.5, baseY + SQRT3 / 2)
+                    val v0 = tiling.getVertex(x, baseY)
+                    val v1 = tiling.getVertex(x + 1.0, baseY)
+                    val v2 = tiling.getVertex(x + 0.5, baseY + SQRT3 / 2)
 
                     val e0 = he(v0); val e1 = he(v1); val e2 = he(v2)
                     connectTwin(v0, v1, e0); connectTwin(v1, v2, e1); connectTwin(v2, v0, e2)
                     registerFace(arrayOf(e0, e1, e2))
                 } else {
-                    // Inverted ∇ shifted half a row down
-                    val v0 = tiling.getVertex(i.toDouble(), baseY + SQRT3 / 2)
-                    val v1 = tiling.getVertex(i + 0.5, baseY)
-                    val v2 = tiling.getVertex(i + 1.0, baseY + SQRT3 / 2)
+                    // Inverted ∇ shifted half a row down and half cell left/right
+                    val v0 = tiling.getVertex(x, baseY)
+                    val v1 = tiling.getVertex(x - 0.5, baseY + SQRT3 / 2)
+                    val v2 = tiling.getVertex(x + 0.5, baseY + SQRT3 / 2)
 
                     val e0 = he(v0); val e1 = he(v1); val e2 = he(v2)
                     connectTwin(v0, v1, e0); connectTwin(v1, v2, e1); connectTwin(v2, v0, e2)


### PR DESCRIPTION
## Summary
- adjust hex grid orientation so adjacent cells share vertices
- offset triangle rows horizontally and correct inverted triangle coords

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687ea94f0ba88324b688ee760d372834