### PR TITLE
Scale grids

### DIFF
--- a/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
@@ -156,7 +156,14 @@ private fun GameBoard(vm: GameViewModel, tileSize: androidx.compose.ui.unit.Dp) 
         )
     }
     val bounds = remember(tiling) { tiling.modelBounds() }
-    val renderer = remember(tileSizePx, bounds) { TilingRenderer(tileSizePx, bounds) }
+    val scaleMultiplier = when (config.gridType) {
+        GridType.HEXAGON -> 2f / 3f
+        GridType.TRIANGLE -> 0.75f
+        else -> 1f
+    }
+    val renderer = remember(tileSizePx, bounds, scaleMultiplier) {
+        TilingRenderer(tileSizePx * scaleMultiplier, bounds)
+    }
     
     // Map tiles to faces (same order as GameEngine)
     val tileToFace = remember(tiling, vm.board) {


### PR DESCRIPTION
## Summary
- make hexagon and triangle grids smaller on screen

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687eafa271e88324ac75e13275e93389