### PR TITLE
Fix triangle grid vertex bounds

### DIFF
--- a/app/src/main/java/com/edgefield/minesweeper/GridSystem.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GridSystem.kt
@@ -225,8 +225,10 @@ class TriangleGridBuilder(
 
     override fun build(): Tiling {
         // Precompute all vertex positions on the triangular lattice
+        // We allocate one extra column of vertices so that the final column
+        // calculations that access i + 1 + rowParity remain safe on odd rows.
         val vertexGrid = Array(rows + 1) { j ->
-            Array(cols + 1) { i ->
+            Array(cols + 2) { i ->
                 val x = i + 0.5 * (j % 2)
                 val y = j * SQRT3 / 2
                 tiling.getVertex(x, y)


### PR DESCRIPTION
## Summary
- avoid ArrayIndexOutOfBoundsException in triangular tiling by allocating an extra column of vertices

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687edd87b18c8324b3faa086141e77d3