### PR TITLE
Add neighbor count policy

### DIFF
--- a/app/src/main/java/com/edgefield/minesweeper/GameEngine.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameEngine.kt
@@ -195,7 +195,8 @@ class GameEngine(private val config: GameConfig) {
             faceToTile[neighborFace]
         }.toMutableList()
 
-        if (config.gridType == GridType.SQUARE) {
+        val kind = config.gridType.kind
+        if (kind == GridKind.SQUARE && kind.neighborCount > adjacent.size) {
             // Add diagonal neighbours that aren't represented in the topology
             val diagOffsets = listOf(-1 to -1, -1 to 1, 1 to -1, 1 to 1)
             diagOffsets.forEach { (dx, dy) ->

--- a/app/src/main/java/com/edgefield/minesweeper/GridSystem.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GridSystem.kt
@@ -378,7 +378,16 @@ class TilingRenderer(val size: Float, bounds: Bounds) {
 //  7 ▍ Convenience factory so the caller never sees builder classes directly
 //──────────────────────────────────────────────────────────────────────────────
 
-enum class GridKind { SQUARE, TRIANGLE, HEXAGON, OCTASQUARE, CAIRO, RHOMBILLE, SNUB_SQUARE, PENROSE }
+enum class GridKind(val neighborCount: Int) {
+    SQUARE(8),
+    TRIANGLE(3),
+    HEXAGON(6),
+    OCTASQUARE(8),
+    CAIRO(5),
+    RHOMBILLE(6),
+    SNUB_SQUARE(5),
+    PENROSE(6)
+}
 
 object GridFactory {
     fun build(kind: GridKind, w:Int, h:Int = w): Tiling = when(kind) {

--- a/app/src/test/java/com/edgefield/minesweeper/GridSystemTest.kt
+++ b/app/src/test/java/com/edgefield/minesweeper/GridSystemTest.kt
@@ -1,6 +1,7 @@
 package com.edgefield.minesweeper
 
 import org.junit.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
@@ -26,5 +27,22 @@ class GridSystemTest {
         val firstFace = squareTiling.faces[0]
         val neighbors = squareTiling.neighbours(firstFace)
         assertTrue(neighbors.isNotEmpty(), "First square face should have neighbors")
+    }
+
+    private fun invokeNeighbors(engine: GameEngine, tile: Tile): List<Tile> {
+        val m = GameEngine::class.java.getDeclaredMethod("neighbors", Tile::class.java)
+        m.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        return m.invoke(engine, tile) as List<Tile>
+    }
+
+    @Test
+    fun neighborCountAcrossGrids() {
+        listOf(GridType.SQUARE, GridType.HEXAGON, GridType.TRIANGLE).forEach { type ->
+            val engine = GameEngine(GameConfig(rows = 3, cols = 3, mineCount = 0, gridType = type))
+            val center = engine.board[1][1]
+            val count = invokeNeighbors(engine, center).size
+            assertEquals(type.kind.neighborCount, count, "${type.name} neighbor count")
+        }
     }
 }


### PR DESCRIPTION
## Summary
- track neighbor count in `GridKind`
- use neighbor policy when finding neighbors
- test neighbor counts for several grids

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fa8f15ee083249b91e629321139bb