### PR TITLE
Add diagonal adjacency to square grid

### DIFF
--- a/app/src/main/java/com/edgefield/minesweeper/GameEngine.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameEngine.kt
@@ -195,22 +195,6 @@ class GameEngine(private val config: GameConfig) {
             faceToTile[neighborFace]
         }.toMutableList()
 
-        val kind = config.gridType.kind
-        if (kind == GridKind.SQUARE && kind.neighborCount > adjacent.size) {
-            // Add diagonal neighbours that aren't represented in the topology
-            val diagOffsets = listOf(-1 to -1, -1 to 1, 1 to -1, 1 to 1)
-            diagOffsets.forEach { (dx, dy) ->
-                val nx = tile.x + dx
-                val ny = tile.y + dy
-                if (nx in 0 until config.cols && ny in 0 until config.rows) {
-                    val diagTile = board[ny][nx]
-                    if (diagTile !in adjacent) {
-                        adjacent += diagTile
-                    }
-                }
-            }
-        }
-
         return adjacent
     }
 }

--- a/app/src/main/java/com/edgefield/minesweeper/GridSystem.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GridSystem.kt
@@ -55,6 +55,13 @@ class Tiling internal constructor(
     internal val faces   : MutableList<Face>,
     private  val vTable  : MutableMap<VKey,Vertex>
 ) {
+    private val extras = mutableMapOf<Face, MutableSet<Face>>()
+
+    internal fun addAdjacency(a: Face, b: Face) {
+        extras.getOrPut(a) { mutableSetOf() }.add(b)
+        extras.getOrPut(b) { mutableSetOf() }.add(a)
+    }
+
     /** Returns the other cells that share an edge with f in O(#edges). */
     fun neighbours(f: Face): List<Face> {
         val out = mutableListOf<Face>()
@@ -71,6 +78,7 @@ class Tiling internal constructor(
             }
             e = e.next
         } while(e !== f.any)
+        extras[f]?.let { out.addAll(it) }
         return out
     }
 
@@ -238,8 +246,28 @@ private val TRIANGLE_DEFINITION = PolygonDefinition(
 //──────────────────────────────────────────────────────────────────────────────
 
 /** Square grid (classic). neighbourMode = 4 or 8 directions (logic‑side). */
-class SquareGridBuilder(cols: Int, rows: Int) :
-    GenericGridBuilder(SQUARE_DEFINITION, cols, rows)
+class SquareGridBuilder(private val cols: Int, private val rows: Int) :
+    GenericGridBuilder(SQUARE_DEFINITION, cols, rows) {
+    override fun build(): Tiling {
+        val t = super.build()
+        for (r in 0 until rows) {
+            for (c in 0 until cols) {
+                val idx = r * cols + c
+                val face = t.faces[idx]
+                val offs = listOf(-1 to -1, -1 to 1, 1 to -1, 1 to 1)
+                offs.forEach { (dx, dy) ->
+                    val nx = c + dx
+                    val ny = r + dy
+                    if (nx in 0 until cols && ny in 0 until rows) {
+                        val neighbor = t.faces[ny * cols + nx]
+                        t.addAdjacency(face, neighbor)
+                    }
+                }
+            }
+        }
+        return t
+    }
+}
 /*
 * Regular hex grid using axial q,r indices. Creates a parallelogram [w×h]. */
 class HexGridBuilder(w: Int, h: Int) :

--- a/app/src/test/java/com/edgefield/minesweeper/GridSystemTest.kt
+++ b/app/src/test/java/com/edgefield/minesweeper/GridSystemTest.kt
@@ -29,20 +29,13 @@ class GridSystemTest {
         assertTrue(neighbors.isNotEmpty(), "First square face should have neighbors")
     }
 
-    private fun invokeNeighbors(engine: GameEngine, tile: Tile): List<Tile> {
-        val m = GameEngine::class.java.getDeclaredMethod("neighbors", Tile::class.java)
-        m.isAccessible = true
-        @Suppress("UNCHECKED_CAST")
-        return m.invoke(engine, tile) as List<Tile>
-    }
-
     @Test
     fun neighborCountAcrossGrids() {
-        listOf(GridType.SQUARE, GridType.HEXAGON, GridType.TRIANGLE).forEach { type ->
-            val engine = GameEngine(GameConfig(rows = 3, cols = 3, mineCount = 0, gridType = type))
-            val center = engine.board[1][1]
-            val count = invokeNeighbors(engine, center).size
-            assertEquals(type.kind.neighborCount, count, "${type.name} neighbor count")
+        listOf(GridKind.SQUARE, GridKind.HEXAGON, GridKind.TRIANGLE).forEach { kind ->
+            val tiling = GridFactory.build(kind, 3, 3)
+            val centerFace = tiling.faces[4]
+            val count = tiling.neighbours(centerFace).size
+            assertEquals(kind.neighborCount, count, "${kind.name} neighbor count")
         }
     }
 }


### PR DESCRIPTION
## Summary
- store supplemental adjacency lists in `Tiling`
- generate diagonal neighbours in `SquareGridBuilder`
- remove special case logic from `GameEngine`
- update tests to verify neighbour count via tiling

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fb43007a48324a3075f43e3cdc361