### PR TITLE
Add new difficulties and custom mines

### DIFF
--- a/app/src/main/java/com/edgefield/minesweeper/GameComponents.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameComponents.kt
@@ -53,6 +53,39 @@ fun GridTypeSelector(
 }
 
 @Composable
+fun DifficultySelector(
+    selected: Difficulty,
+    onSelected: (Difficulty) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        Text("Difficulty", style = MaterialTheme.typography.titleMedium)
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Difficulty.values().forEach { diff ->
+            val name = diff.name.replace('_', ' ').lowercase().replaceFirstChar { it.titlecase() }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .selectable(
+                        selected = selected == diff,
+                        onClick = { onSelected(diff) }
+                    )
+                    .padding(vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                RadioButton(
+                    selected = selected == diff,
+                    onClick = { onSelected(diff) }
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(name)
+            }
+        }
+    }
+}
+
+@Composable
 fun DifficultyPresets(
     onPresetSelected: (GameConfig) -> Unit,
     modifier: Modifier = Modifier
@@ -62,9 +95,13 @@ fun DifficultyPresets(
         Spacer(modifier = Modifier.height(8.dp))
         
         val presets = listOf(
-            "Beginner" to GameConfig(rows = 9, cols = 9, mineCount = 10),
-            "Intermediate" to GameConfig(rows = 16, cols = 16, mineCount = 40),
-            "Expert" to GameConfig(rows = 16, cols = 30, mineCount = 99)
+            "Very Easy" to GameConfig(difficulty = Difficulty.VERY_EASY),
+            "Easy" to GameConfig(difficulty = Difficulty.EASY),
+            "Medium" to GameConfig(difficulty = Difficulty.MEDIUM),
+            "Hard" to GameConfig(difficulty = Difficulty.HARD),
+            "Very Hard" to GameConfig(difficulty = Difficulty.VERY_HARD),
+            "Hardest" to GameConfig(difficulty = Difficulty.HARDEST),
+            "Custom" to GameConfig(difficulty = Difficulty.CUSTOM)
         )
         
         presets.forEach { (name, config) ->

--- a/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
@@ -406,17 +406,37 @@ private fun SettingsDialog(
                 }
                 
                 Spacer(modifier = Modifier.height(8.dp))
-                
-                OutlinedTextField(
-                    value = tempConfig.mineCount.toString(),
-                    onValueChange = { 
-                        it.toIntOrNull()?.let { mines ->
-                            val maxMines = (tempConfig.rows * tempConfig.cols * 0.3).toInt()
-                            tempConfig = tempConfig.copy(mineCount = mines.coerceIn(1, maxMines))
-                        }
-                    },
-                    label = { Text("Mine Count") }
+
+                DifficultySelector(
+                    selected = tempConfig.difficulty,
+                    onSelected = { tempConfig = tempConfig.copy(difficulty = it) }
                 )
+
+                if (tempConfig.difficulty == Difficulty.CUSTOM) {
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text("Use Percentage")
+                        Spacer(Modifier.width(8.dp))
+                        Switch(
+                            checked = tempConfig.useMinePercent,
+                            onCheckedChange = { tempConfig = tempConfig.copy(useMinePercent = it) }
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    OutlinedTextField(
+                        value = tempConfig.customMines.toString(),
+                        onValueChange = {
+                            it.toIntOrNull()?.let { value ->
+                                val max = tempConfig.rows * tempConfig.cols - 1
+                                tempConfig = tempConfig.copy(customMines = value.coerceIn(1, max))
+                            }
+                        },
+                        label = { Text(if (tempConfig.useMinePercent) "Mine %" else "Mine Count") }
+                    )
+                }
                 
                 Spacer(modifier = Modifier.height(8.dp))
                 

--- a/app/src/main/java/com/edgefield/minesweeper/TileModels.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/TileModels.kt
@@ -9,6 +9,16 @@ enum class GridType {
     SQUARE, TRIANGLE, HEXAGON, OCTASQUARE, CAIRO, RHOMBILLE, SNUB_SQUARE, PENROSE
 }
 
+enum class Difficulty(val percent: Int) {
+    VERY_EASY(5),
+    EASY(10),
+    MEDIUM(15),
+    HARD(20),
+    VERY_HARD(25),
+    HARDEST(30),
+    CUSTOM(15)
+}
+
 val GridType.kind: GridKind
     get() = GridKind.valueOf(name)
 
@@ -26,11 +36,28 @@ data class TouchConfig(
 data class GameConfig(
     val rows: Int = 10,
     val cols: Int = 10,
-    val mineCount: Int = 15,
+    val difficulty: Difficulty = Difficulty.MEDIUM,
+    val customMines: Int = 15,
+    val useMinePercent: Boolean = false,
     val gridType: GridType = GridType.SQUARE,
     val edgeMode: Boolean = true,
     val touchConfig: TouchConfig = TouchConfig()
-)
+) {
+    val mineCount: Int
+        get() {
+            val cells = rows * cols
+            return when (difficulty) {
+                Difficulty.CUSTOM -> {
+                    if (useMinePercent) {
+                        (cells * customMines / 100.0).toInt().coerceIn(1, cells - 1)
+                    } else {
+                        customMines.coerceIn(1, cells - 1)
+                    }
+                }
+                else -> (cells * difficulty.percent / 100).coerceIn(1, cells - 1)
+            }
+        }
+}
 
 data class GameStats(
     val startTime: Long = System.currentTimeMillis(),


### PR DESCRIPTION
## Summary
- introduce `Difficulty` enum
- compute mine count from difficulty or custom settings
- add `DifficultySelector` UI component
- update settings dialog with new difficulty options and custom mine toggle

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fbd86cd708324a69014aced5314e0