### PR TITLE
Add persistent settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ You can also open the project in Android Studio and run it directly from the IDE
 - Several board layouts: Square, Triangle, Hexagon, Octasquare, Cairo, Rhombille, Snub Square and Penrose.
 - Configurable edge wrapping (left/right, top/bottom or full torus).
 - Gesture-based controls with zoom and pan support.
+- Settings are saved between sessions.
 
 ### Selecting a Grid Type
 

--- a/app/src/main/java/com/edgefield/minesweeper/GameViewModel.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameViewModel.kt
@@ -1,17 +1,19 @@
 // ───────────────── GameViewModel.kt ─────────────────
 package com.edgefield.minesweeper
 
+import android.app.Application
 import android.util.Log
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.edgefield.minesweeper.PrefsManager
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.isActive
 
-class GameViewModel : ViewModel() {
+class GameViewModel(application: Application) : AndroidViewModel(application) {
 
     var gameConfig by mutableStateOf(GameConfig())
         private set
@@ -31,6 +33,7 @@ class GameViewModel : ViewModel() {
     init {
         Log.d("GameViewModel", "Initializing GameViewModel")
         try {
+            gameConfig = PrefsManager.loadGameConfig(getApplication())
             Log.d("GameViewModel", "Creating GameEngine with config: $gameConfig")
             engine = GameEngine(gameConfig)
             Log.d("GameViewModel", "GameEngine created successfully")
@@ -93,6 +96,7 @@ class GameViewModel : ViewModel() {
 
     fun updateConfig(newConfig: GameConfig) {
         gameConfig = newConfig
+        PrefsManager.saveGameConfig(getApplication(), newConfig)
         reset()
     }
 

--- a/app/src/main/java/com/edgefield/minesweeper/PrefsManager.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/PrefsManager.kt
@@ -1,0 +1,57 @@
+package com.edgefield.minesweeper
+
+import android.content.Context
+
+object PrefsManager {
+    private const val PREFS_NAME = "minesweeper_prefs"
+
+    fun loadGameConfig(context: Context): GameConfig {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val rows = prefs.getInt("rows", 10)
+        val cols = prefs.getInt("cols", 10)
+        val difficultyName = prefs.getString("difficulty", Difficulty.MEDIUM.name) ?: Difficulty.MEDIUM.name
+        val difficulty = Difficulty.valueOf(difficultyName)
+        val customMines = prefs.getInt("customMines", 15)
+        val usePercent = prefs.getBoolean("useMinePercent", false)
+        val gridTypeName = prefs.getString("gridType", GridType.SQUARE.name) ?: GridType.SQUARE.name
+        val gridType = GridType.valueOf(gridTypeName)
+        val edgeMode = prefs.getBoolean("edgeMode", true)
+        val singleTap = prefs.getString("singleTap", TouchAction.MARK_CYCLE.name) ?: TouchAction.MARK_CYCLE.name
+        val doubleTap = prefs.getString("doubleTap", TouchAction.FLAG.name) ?: TouchAction.FLAG.name
+        val tripleTap = prefs.getString("tripleTap", TouchAction.REVEAL.name) ?: TouchAction.REVEAL.name
+        val longPress = prefs.getString("longPress", TouchAction.NONE.name) ?: TouchAction.NONE.name
+        val touchConfig = TouchConfig(
+            singleTap = TouchAction.valueOf(singleTap),
+            doubleTap = TouchAction.valueOf(doubleTap),
+            tripleTap = TouchAction.valueOf(tripleTap),
+            longPress = TouchAction.valueOf(longPress)
+        )
+        return GameConfig(
+            rows = rows,
+            cols = cols,
+            difficulty = difficulty,
+            customMines = customMines,
+            useMinePercent = usePercent,
+            gridType = gridType,
+            edgeMode = edgeMode,
+            touchConfig = touchConfig
+        )
+    }
+
+    fun saveGameConfig(context: Context, config: GameConfig) {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        prefs.edit()
+            .putInt("rows", config.rows)
+            .putInt("cols", config.cols)
+            .putString("difficulty", config.difficulty.name)
+            .putInt("customMines", config.customMines)
+            .putBoolean("useMinePercent", config.useMinePercent)
+            .putString("gridType", config.gridType.name)
+            .putBoolean("edgeMode", config.edgeMode)
+            .putString("singleTap", config.touchConfig.singleTap.name)
+            .putString("doubleTap", config.touchConfig.doubleTap.name)
+            .putString("tripleTap", config.touchConfig.tripleTap.name)
+            .putString("longPress", config.touchConfig.longPress.name)
+            .apply()
+    }
+}


### PR DESCRIPTION
## Summary
- save settings to SharedPreferences
- load saved config when the ViewModel starts
- document that settings persist

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fc0ec2b4483248bded899a119ffe3