### PR TITLE
Fix automatic blank reveal

### DIFF
--- a/app/src/main/java/com/edgefield/minesweeper/TileModels.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/TileModels.kt
@@ -70,11 +70,26 @@ data class GameStats(
     val efficiency: Double get() = if (totalMoves > 0) (minesFound.toDouble() / totalMoves) * 100.0 else 0.0
 }
 
-data class Tile(
+class Tile(
     val x: Int,
     val y: Int,
     var hasMine: Boolean = false,
     var revealed: Boolean = false,
     var mark: Mark = Mark.NONE,
     var adjMines: Int = 0
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Tile) return false
+        return x == other.x && y == other.y
+    }
+
+    override fun hashCode(): Int {
+        var result = x
+        result = 31 * result + y
+        return result
+    }
+
+    override fun toString(): String =
+        "Tile(x=$x, y=$y, hasMine=$hasMine, revealed=$revealed, mark=$mark, adjMines=$adjMines)"
+}


### PR DESCRIPTION
## Summary
- make Tile equality depend only on coordinates so flood fill works

## Testing
- `gradle assembleDebug --console=plain | tail -n 20` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fd08298808324b862278c93930d33