### PR TITLE
Show X for wrong flags

### DIFF
--- a/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
@@ -336,14 +336,25 @@ private fun DrawScope.drawTileOverlays(tile: Tile, center: Offset, tileSizePx: F
             center = center
         )
     } else if (!tile.revealed && tile.mark == Mark.FLAG) {
-        // Draw green checkmark
         val stroke = 2.dp.toPx()
         val size = tileSizePx * 0.4f
-        val start = Offset(center.x - size / 2f, center.y)
-        val mid = Offset(center.x - size / 8f, center.y + size / 2f)
-        val end = Offset(center.x + size / 2f, center.y - size / 2f)
-        drawLine(Color(0xFF4CAF50), start, mid, strokeWidth = stroke)
-        drawLine(Color(0xFF4CAF50), mid, end, strokeWidth = stroke)
+        if (gameState == GameState.LOST && !tile.hasMine) {
+            // Draw red X for incorrect flag
+            val half = size / 2f
+            val topLeft = Offset(center.x - half, center.y - half)
+            val topRight = Offset(center.x + half, center.y - half)
+            val bottomLeft = Offset(center.x - half, center.y + half)
+            val bottomRight = Offset(center.x + half, center.y + half)
+            drawLine(Color.Red, topLeft, bottomRight, strokeWidth = stroke)
+            drawLine(Color.Red, topRight, bottomLeft, strokeWidth = stroke)
+        } else {
+            // Draw green checkmark
+            val start = Offset(center.x - size / 2f, center.y)
+            val mid = Offset(center.x - size / 8f, center.y + size / 2f)
+            val end = Offset(center.x + size / 2f, center.y - size / 2f)
+            drawLine(Color(0xFF4CAF50), start, mid, strokeWidth = stroke)
+            drawLine(Color(0xFF4CAF50), mid, end, strokeWidth = stroke)
+        }
     } else if (!tile.revealed && tile.mark == Mark.QUESTION) {
         // Draw question mark
         drawCircle(


### PR DESCRIPTION
## Summary
- mark flagged tiles without mines with a red `X` when the game is over

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687fd8f0ca78832492048e25621b09b2