### PR TITLE
Add darker water color for flagged tiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ You can also open the project in Android Studio and run it directly from the IDE
 - Configurable edge wrapping (left/right, top/bottom or full torus).
 - Gesture-based controls with zoom and pan support.
 - Settings are saved between sessions.
+- Flags appear as darker water and return to gray when removed.
 
 ### Selecting a Grid Type
 

--- a/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
@@ -444,7 +444,7 @@ private fun GameBoard(vm: GameViewModel, tileSize: androidx.compose.ui.unit.Dp) 
 
 private fun getTileColor(tile: Tile, gameState: GameState): Color {
     return when {
-        !tile.revealed && tile.mark == Mark.FLAG -> Color(0xFF9E9E9E) // Same gray as unrevealed
+        !tile.revealed && tile.mark == Mark.FLAG -> Color(0xFF64B5F6) // Darker blue water for flagged tiles
         !tile.revealed && tile.mark == Mark.QUESTION -> Color(0xFFFF9800) // Orange for questions
         !tile.revealed -> Color(0xFF9E9E9E) // Gray for unrevealed
         tile.hasMine && gameState == GameState.LOST -> Color(0xFFF44336) // Red for mines


### PR DESCRIPTION
## Summary
- show flagged tiles as darker water
- document flag color in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fe0cb1c188324aade3c9307c9c917