### PR TITLE
Implement game state persistence

### DIFF
--- a/app/src/main/java/com/edgefield/minesweeper/GameEngine.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameEngine.kt
@@ -267,4 +267,43 @@ class GameEngine(private val config: GameConfig) {
         val wy = ((y % config.rows) + config.rows) % config.rows
         return wx to wy
     }
+
+    fun exportState(): EngineState {
+        val boardCopy = Array(board.size) { r ->
+            Array(board[r].size) { c ->
+                val t = board[r][c]
+                Tile(t.x, t.y, t.hasMine, t.revealed, t.mark, t.adjMines)
+            }
+        }
+        return EngineState(
+            board = boardCopy,
+            gameState = gameState,
+            firstClick = firstClick,
+            stats = stats.copy()
+        )
+    }
+
+    fun loadState(state: EngineState) {
+        require(state.board.size == config.rows &&
+            state.board[0].size == config.cols) {
+            "Board size mismatch"
+        }
+        for (y in board.indices) {
+            for (x in board[y].indices) {
+                val src = state.board[y][x]
+                val dst = board[y][x]
+                dst.hasMine = src.hasMine
+                dst.revealed = src.revealed
+                dst.mark = src.mark
+                dst.adjMines = src.adjMines
+            }
+        }
+        firstClick = state.firstClick
+        gameState = state.gameState
+        stats.startTime = state.stats.startTime
+        stats.endTime = state.stats.endTime
+        stats.processCount = state.stats.processCount
+        stats.totalMoves = state.stats.totalMoves
+        stats.minesFound = state.stats.minesFound
+    }
 }

--- a/app/src/main/java/com/edgefield/minesweeper/GameStateModels.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameStateModels.kt
@@ -1,0 +1,9 @@
+package com.edgefield.minesweeper
+
+/** Holds the serializable state of the game engine. */
+data class EngineState(
+    val board: Array<Array<Tile>>,
+    val gameState: GameState,
+    val firstClick: Boolean,
+    val stats: GameStats
+)

--- a/app/src/main/java/com/edgefield/minesweeper/GameViewModel.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameViewModel.kt
@@ -144,4 +144,16 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
             }
         }
     }
+
+    fun saveState() {
+        PrefsManager.saveGameState(getApplication(), engine.exportState())
+    }
+
+    fun loadState() {
+        PrefsManager.loadGameState(getApplication(), gameConfig)?.let { state ->
+            engine = GameEngine(gameConfig)
+            engine.loadState(state)
+            updateState()
+        }
+    }
 }

--- a/app/src/main/java/com/edgefield/minesweeper/MainActivity.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/MainActivity.kt
@@ -7,9 +7,10 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.activity.viewModels
 
 class MainActivity : ComponentActivity() {
+    private val vm: GameViewModel by viewModels()
     override fun onCreate(savedInstanceState: Bundle?) {
         Log.d("MainActivity", "onCreate started")
         super.onCreate(savedInstanceState)
@@ -20,9 +21,7 @@ class MainActivity : ComponentActivity() {
                 Log.d("MainActivity", "Inside setContent")
                 MaterialTheme {
                     Surface {
-                        Log.d("MainActivity", "Creating ViewModel")
-                        val vm: GameViewModel = viewModel()
-                        Log.d("MainActivity", "ViewModel created, showing GameScreen")
+                        Log.d("MainActivity", "Showing GameScreen")
                         GameScreen(vm)
                     }
                 }
@@ -32,5 +31,15 @@ class MainActivity : ComponentActivity() {
             Log.e("MainActivity", "Error in onCreate", e)
             throw e
         }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        vm.saveState()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        vm.loadState()
     }
 }

--- a/app/src/main/java/com/edgefield/minesweeper/PrefsManager.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/PrefsManager.kt
@@ -5,6 +5,15 @@ import android.content.Context
 object PrefsManager {
     private const val PREFS_NAME = "minesweeper_prefs"
 
+    private const val KEY_BOARD = "board"
+    private const val KEY_STATE = "state"
+    private const val KEY_FIRST_CLICK = "first_click"
+    private const val KEY_START_TIME = "start_time"
+    private const val KEY_END_TIME = "end_time"
+    private const val KEY_PROCESS_COUNT = "process_count"
+    private const val KEY_TOTAL_MOVES = "total_moves"
+    private const val KEY_MINES_FOUND = "mines_found"
+
     fun loadGameConfig(context: Context): GameConfig {
         val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
         val rows = prefs.getInt("rows", 10)
@@ -53,5 +62,84 @@ object PrefsManager {
             .putString("tripleTap", config.touchConfig.tripleTap.name)
             .putString("longPress", config.touchConfig.longPress.name)
             .apply()
+    }
+
+    fun saveGameState(context: Context, state: EngineState) {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        prefs.edit()
+            .putString(KEY_BOARD, serializeBoard(state.board))
+            .putString(KEY_STATE, state.gameState.name)
+            .putBoolean(KEY_FIRST_CLICK, state.firstClick)
+            .putLong(KEY_START_TIME, state.stats.startTime)
+            .putLong(KEY_END_TIME, state.stats.endTime ?: -1L)
+            .putInt(KEY_PROCESS_COUNT, state.stats.processCount)
+            .putInt(KEY_TOTAL_MOVES, state.stats.totalMoves)
+            .putInt(KEY_MINES_FOUND, state.stats.minesFound)
+            .apply()
+    }
+
+    fun loadGameState(context: Context, config: GameConfig): EngineState? {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val boardData = prefs.getString(KEY_BOARD, null) ?: return null
+        val board = deserializeBoard(boardData)
+        if (board.size != config.rows || board[0].size != config.cols) return null
+        val stats = GameStats(
+            startTime = prefs.getLong(KEY_START_TIME, System.currentTimeMillis()),
+            endTime = prefs.getLong(KEY_END_TIME, -1L).let { if (it == -1L) null else it },
+            processCount = prefs.getInt(KEY_PROCESS_COUNT, 0),
+            totalMoves = prefs.getInt(KEY_TOTAL_MOVES, 0),
+            minesFound = prefs.getInt(KEY_MINES_FOUND, 0)
+        )
+        val gameState = GameState.valueOf(prefs.getString(KEY_STATE, GameState.PLAYING.name)!!)
+        val firstClick = prefs.getBoolean(KEY_FIRST_CLICK, true)
+        return EngineState(board, gameState, firstClick, stats)
+    }
+
+    fun clearGameState(context: Context) {
+        val prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        prefs.edit()
+            .remove(KEY_BOARD)
+            .remove(KEY_STATE)
+            .remove(KEY_FIRST_CLICK)
+            .remove(KEY_START_TIME)
+            .remove(KEY_END_TIME)
+            .remove(KEY_PROCESS_COUNT)
+            .remove(KEY_TOTAL_MOVES)
+            .remove(KEY_MINES_FOUND)
+            .apply()
+    }
+
+    private fun serializeBoard(board: Array<Array<Tile>>): String {
+        return buildString {
+            append(board.size).append(',').append(board[0].size).append('|')
+            board.forEach { row ->
+                row.forEach { tile ->
+                    append(if (tile.hasMine) '1' else '0').append(':')
+                    append(if (tile.revealed) '1' else '0').append(':')
+                    append(tile.mark.ordinal).append(':')
+                    append(tile.adjMines).append(';')
+                }
+                append('|')
+            }
+        }
+    }
+
+    private fun deserializeBoard(data: String): Array<Array<Tile>> {
+        val parts = data.split('|')
+        val dims = parts[0].split(',')
+        val rows = dims[0].toInt()
+        val cols = dims[1].toInt()
+        val board = Array(rows) { r -> Array(cols) { c -> Tile(c, r) } }
+        parts.drop(1).filter { it.isNotEmpty() }.forEachIndexed { r, row ->
+            row.split(';').filter { it.isNotEmpty() }.forEachIndexed { c, tile ->
+                val vals = tile.split(':')
+                val t = board[r][c]
+                t.hasMine = vals[0] == "1"
+                t.revealed = vals[1] == "1"
+                t.mark = Mark.values()[vals[2].toInt()]
+                t.adjMines = vals[3].toInt()
+            }
+        }
+        return board
     }
 }


### PR DESCRIPTION
## Summary
- add `EngineState` model
- support exporting and loading state in `GameEngine`
- persist state with `PrefsManager`
- expose `saveState` and `loadState` in `GameViewModel`
- handle save/resume in `MainActivity`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687fe825d6ac83249359e81ed702daf3