### PR TITLE
Prevent hex ghost overlap

### DIFF
--- a/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
@@ -423,7 +423,9 @@ private fun GameBoard(vm: GameViewModel, tileSize: androidx.compose.ui.unit.Dp) 
                                 baseCenter.x + step.x - wrappedCenter.x,
                                 baseCenter.y + step.y - wrappedCenter.y
                             )
-                            drawFace(wrappedTile, wrappedFace, offset, true)
+                            if (offset != Offset.Zero) {
+                                drawFace(wrappedTile, wrappedFace, offset, true)
+                            }
                         }
                     }
                 }
@@ -531,7 +533,9 @@ private fun GameBoard(vm: GameViewModel, tileSize: androidx.compose.ui.unit.Dp) 
                             baseCenter.x + step.x - wrappedCenter.x,
                             baseCenter.y + step.y - wrappedCenter.y
                         )
-                        drawNumber(wrappedTile, wrappedFace, offset, true)
+                        if (offset != Offset.Zero) {
+                            drawNumber(wrappedTile, wrappedFace, offset, true)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- avoid drawing overlapping ghost tiles in edge mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ff824d7bc8324bb7bf4586933acf1