### PR TITLE
Fix GameScreen strings

### DIFF
--- a/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
@@ -63,18 +63,18 @@ fun GameScreen(vm: GameViewModel) {
             title = {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     Text(
-                        "Mines: ${$'vm.getRemainingMines()}/${$'vm.gameConfig.mineCount}",
+                        "Mines: ${vm.getRemainingMines()}/${vm.gameConfig.mineCount}",
                         style = MaterialTheme.typography.bodyMedium,
                         fontWeight = FontWeight.Bold
                     )
                     Text(" > ")
                     Text(
-                        "Time: ${$'vm.getElapsedTimeFormatted()}",
+                        "Time: ${vm.getElapsedTimeFormatted()}",
                         style = MaterialTheme.typography.bodyMedium
                     )
                     Text(" > ")
                     Text(
-                        "Moves: ${$'vm.stats.totalMoves}",
+                        "Moves: ${vm.stats.totalMoves}",
                         style = MaterialTheme.typography.bodyMedium
                     )
                 }


### PR DESCRIPTION
## Summary
- correct interpolation syntax in top bar strings

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688013c1d78083248e118d4f5cf2186c