### PR TITLE
Fix clipping on game board

### DIFF
--- a/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.*
-import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Refresh
@@ -101,8 +100,7 @@ fun GameScreen(vm: GameViewModel) {
             modifier = Modifier
                 .weight(1f)
                 .fillMaxWidth()
-                .padding(horizontal = 8.dp)
-                .clipToBounds(),
+                .padding(horizontal = 8.dp),
             contentAlignment = Alignment.Center
         ) {
             GameBoard(vm, tileSize)
@@ -283,7 +281,7 @@ private fun GameBoard(vm: GameViewModel, tileSize: androidx.compose.ui.unit.Dp) 
                 translationY = pan.y
                 scaleX = scale
                 scaleY = scale
-                clip = true
+                clip = false
             }
             .pointerInput(Unit) {
                 detectTransformGestures { centroid, panChange, zoom, _ ->


### PR DESCRIPTION
## Summary
- ensure the board box doesn't cut off content
- allow the grid to extend beyond its drawing box

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688019778694832494eff3125958b83d