### PR TITLE
Add graph board builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,15 @@ You can also open the project in Android Studio and run it directly from the IDE
 ### Selecting a Grid Type
 
 Open the Settings screen and pick one of the available tilings. Wrapping options can be toggled per edge. Penrose grids do not support wrapping.
+
+## Graph Board Builders
+
+The `graph` package includes simple utilities for creating boards programmatically.
+
+```kotlin
+val square = graph.buildSquareBoard(cols = 5, rows = 5)
+val triangle = graph.buildTriangleBoard(4, 4)
+val mixed = graph.buildMixedDemoBoard()
+```
+
+Cells are addressed by vertex IDs like `"2_3"`. Use `getCell(id)` to retrieve a cell and inspect its neighbors.

--- a/app/src/test/java/com/edgefield/minesweeper/BoardBuildersTest.kt
+++ b/app/src/test/java/com/edgefield/minesweeper/BoardBuildersTest.kt
@@ -1,0 +1,30 @@
+package com.edgefield.minesweeper
+
+import graph.buildSquareBoard
+import graph.buildTriangleBoard
+import graph.buildMixedDemoBoard
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class BoardBuildersTest {
+    @Test
+    fun squareBoardNeighborCount() {
+        val board = buildSquareBoard(3, 3)
+        val center = board.getCell("1_1")!!
+        assertEquals(8, center.neighbors.size)
+    }
+
+    @Test
+    fun triangleBoardNeighborCount() {
+        val board = buildTriangleBoard(3, 3)
+        val center = board.getCell("1_1")!!
+        assertEquals(3, center.neighbors.size)
+    }
+
+    @Test
+    fun mixedBoardIsNotEmpty() {
+        val board = buildMixedDemoBoard()
+        assertTrue(board.cells.isNotEmpty())
+    }
+}

--- a/graph/BoardBuilders.kt
+++ b/graph/BoardBuilders.kt
@@ -1,0 +1,78 @@
+package graph
+
+fun buildSquareBoard(cols: Int, rows: Int): GameBoard {
+    val board = GameBoard()
+    for (y in 0 until rows) {
+        for (x in 0 until cols) {
+            val id = "${x}_${y}"
+            board.addCell(Cell(id))
+        }
+    }
+    val offsets = listOf(
+        -1 to 0, 1 to 0, 0 to -1, 0 to 1,
+        -1 to -1, -1 to 1, 1 to -1, 1 to 1
+    )
+    for (y in 0 until rows) {
+        for (x in 0 until cols) {
+            val id = "${x}_${y}"
+            offsets.forEach { (dx, dy) ->
+                val nx = x + dx
+                val ny = y + dy
+                if (nx in 0 until cols && ny in 0 until rows) {
+                    board.connect(id, "${nx}_${ny}")
+                }
+            }
+        }
+    }
+    return board
+}
+
+fun buildTriangleBoard(cols: Int, rows: Int): GameBoard {
+    val board = GameBoard()
+    for (y in 0 until rows) {
+        for (x in 0 until cols) {
+            val id = "${x}_${y}"
+            board.addCell(Cell(id))
+        }
+    }
+    for (y in 0 until rows) {
+        for (x in 0 until cols) {
+            val id = "${x}_${y}"
+            val up = (x + y) % 2 == 0
+            val neighbors = if (up) {
+                listOf(-1 to 0, 1 to 0, 0 to 1)
+            } else {
+                listOf(-1 to 0, 1 to 0, 0 to -1)
+            }
+            neighbors.forEach { (dx, dy) ->
+                val nx = x + dx
+                val ny = y + dy
+                if (nx in 0 until cols && ny in 0 until rows) {
+                    board.connect(id, "${nx}_${ny}")
+                }
+            }
+        }
+    }
+    return board
+}
+
+fun buildMixedDemoBoard(): GameBoard {
+    val board = buildSquareBoard(2, 2)
+    val offsetX = 2
+    val triangles = buildTriangleBoard(2, 1)
+    triangles.cells.forEach { cell ->
+        val (x, y) = cell.id.split('_').map { it.toInt() }
+        val newId = "${x + offsetX}_${y}"
+        board.addCell(Cell(newId))
+    }
+    triangles.cells.forEach { cell ->
+        val (x, y) = cell.id.split('_').map { it.toInt() }
+        val id = "${x + offsetX}_${y}"
+        cell.neighbors.forEach { n ->
+            val (nx, ny) = n.id.split('_').map { it.toInt() }
+            board.connect(id, "${nx + offsetX}_${ny}")
+        }
+    }
+    board.connect("1_0", "2_0")
+    return board
+}

--- a/graph/GraphModels.kt
+++ b/graph/GraphModels.kt
@@ -1,0 +1,25 @@
+package graph
+
+data class Cell(val id: String) {
+    val neighbors: MutableSet<Cell> = mutableSetOf()
+}
+
+class GameBoard {
+    private val cellMap = mutableMapOf<String, Cell>()
+
+    fun addCell(cell: Cell) {
+        cellMap[cell.id] = cell
+    }
+
+    fun getCell(id: String): Cell? = cellMap[id]
+
+    fun connect(aId: String, bId: String) {
+        val a = cellMap.getOrPut(aId) { Cell(aId).also { addCell(it) } }
+        val b = cellMap.getOrPut(bId) { Cell(bId).also { addCell(it) } }
+        a.neighbors.add(b)
+        b.neighbors.add(a)
+    }
+
+    val cells: Collection<Cell>
+        get() = cellMap.values
+}


### PR DESCRIPTION
## Summary
- implement simple `GameBoard`/`Cell` models
- add square, triangle and mixed board builders
- document usage in README
- add board builder tests

## Testing
- No tests run due to environment restrictions

------
https://chatgpt.com/codex/tasks/task_e_68805445bf408324b93d112fcc9a2791