### PR TITLE
Add simple graph board

### DIFF
--- a/app/src/main/java/com/edgefield/minesweeper/graph/Cell.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/graph/Cell.kt
@@ -1,0 +1,14 @@
+package com.edgefield.minesweeper.graph
+
+/**
+ * Basic representation of a board cell.
+ */
+data class Cell(
+    val id: String,
+    val vertices: Set<String>,
+    var isMine: Boolean = false,
+    var isRevealed: Boolean = false,
+    var isFlagged: Boolean = false,
+    val neighbors: MutableSet<String> = mutableSetOf()
+)
+

--- a/app/src/main/java/com/edgefield/minesweeper/graph/GameBoard.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/graph/GameBoard.kt
@@ -1,0 +1,41 @@
+package com.edgefield.minesweeper.graph
+
+/**
+ * Simple graph-based board representation.
+ */
+class GameBoard {
+    val cells: MutableMap<String, Cell> = mutableMapOf()
+    val vertexMap: MutableMap<String, MutableSet<String>> = mutableMapOf()
+
+    /**
+     * Adds a new cell to the board. Any existing cells sharing at least one
+     * vertex are automatically connected as neighbours.
+     */
+    fun addCell(cell: Cell) {
+        if (cells.containsKey(cell.id)) return
+        cells[cell.id] = cell
+        cell.vertices.forEach { vertex ->
+            val ids = vertexMap.getOrPut(vertex) { mutableSetOf() }
+            ids.forEach { other -> connect(cell.id, other) }
+            ids.add(cell.id)
+        }
+    }
+
+    /** Connects two cells bidirectionally. */
+    fun connect(a: String, b: String) {
+        if (a == b) return
+        val first = cells[a] ?: return
+        val second = cells[b] ?: return
+        first.neighbors.add(b)
+        second.neighbors.add(a)
+    }
+
+    fun getCell(id: String): Cell? = cells[id]
+
+    fun getNeighbors(id: String): Set<Cell> =
+        cells[id]?.neighbors?.mapNotNull { cells[it] }?.toSet() ?: emptySet()
+
+    fun countNeighborMines(id: String): Int =
+        getNeighbors(id).count { it.isMine }
+}
+

--- a/app/src/test/java/com/edgefield/minesweeper/GameBoardTest.kt
+++ b/app/src/test/java/com/edgefield/minesweeper/GameBoardTest.kt
@@ -1,0 +1,35 @@
+package com.edgefield.minesweeper
+
+import com.edgefield.minesweeper.graph.Cell
+import com.edgefield.minesweeper.graph.GameBoard
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GameBoardTest {
+
+    @Test
+    fun neighboursLinkedWhenVerticesShared() {
+        val board = GameBoard()
+        board.addCell(Cell(id = "A", vertices = setOf("v1", "v2", "v3")))
+        board.addCell(Cell(id = "B", vertices = setOf("v3", "v4")))
+
+        val aNeighbours = board.getNeighbors("A").map { it.id }
+        val bNeighbours = board.getNeighbors("B").map { it.id }
+
+        assertTrue("B" in aNeighbours, "A should link to B")
+        assertTrue("A" in bNeighbours, "B should link back to A")
+    }
+
+    @Test
+    fun countNeighborMinesWorks() {
+        val board = GameBoard()
+        board.addCell(Cell(id = "A", vertices = setOf("v1", "v2", "v3"), isMine = true))
+        board.addCell(Cell(id = "B", vertices = setOf("v3", "v4", "v5")))
+        board.addCell(Cell(id = "C", vertices = setOf("v5", "v6"), isMine = true))
+
+        assertEquals(2, board.countNeighborMines("B"), "B should see two mines")
+        assertEquals(0, board.countNeighborMines("A"), "A should see no mines")
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a `Cell` data class for graph-based boards
- implement `GameBoard` with automatic neighbour wiring
- test neighbour linking and mine counting

## Testing
- `No tests run`

------
https://chatgpt.com/codex/tasks/task_e_688054451c4483249e458b3f5da7c48a