### PR TITLE
Switch UI to cell-based board

### DIFF
--- a/app/src/main/java/com/edgefield/minesweeper/TileFaceMapping.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/TileFaceMapping.kt
@@ -1,5 +1,7 @@
 package com.edgefield.minesweeper
 
+import com.edgefield.minesweeper.graph.Cell
+
 /** Helper to create bidirectional mappings between board tiles and tiling faces. */
 internal fun mapTilesToFaces(
     tiles: List<Tile>,
@@ -16,4 +18,21 @@ internal fun mapTilesToFaces(
         faceToTile[face] = tile
     }
     return tileToFace to faceToTile
+}
+
+internal fun mapCellsToFaces(
+    cells: List<Cell>,
+    faces: List<Face>
+): Pair<Map<Cell, Face>, Map<Face, Cell>> {
+    require(cells.size == faces.size) {
+        "Cell count (${cells.size}) must match face count (${faces.size})"
+    }
+    val cellToFace = mutableMapOf<Cell, Face>()
+    val faceToCell = mutableMapOf<Face, Cell>()
+    cells.forEachIndexed { idx, cell ->
+        val face = faces[idx]
+        cellToFace[cell] = face
+        faceToCell[face] = cell
+    }
+    return cellToFace to faceToCell
 }


### PR DESCRIPTION
## Summary
- track GameBoard inside GameViewModel
- expose cells for rendering and cloning helpers
- draw cells directly in GameScreen using GridSystem
- map graph cells to faces for rendering

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68805afd3c388324a7fc0c57d0899be1