### PR TITLE
Add Face conversion helper

### DIFF
--- a/app/src/main/java/com/edgefield/minesweeper/FaceToCell.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/FaceToCell.kt
@@ -1,0 +1,15 @@
+package com.edgefield.minesweeper
+
+import com.edgefield.minesweeper.graph.Cell
+
+/** Converts a DCEL face into a board cell using vertex keys as IDs. */
+internal fun Face.toCell(id: String): Cell {
+    val vertices = mutableSetOf<String>()
+    var edge = any
+    do {
+        val key = edge.origin.key
+        vertices.add("${key.x}_${key.y}")
+        edge = edge.next
+    } while (edge !== any)
+    return Cell(id = id, vertices = vertices)
+}

--- a/app/src/main/java/com/edgefield/minesweeper/GameEngine.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameEngine.kt
@@ -28,14 +28,7 @@ class GameEngine(private val config: GameConfig) {
         for (y in 0 until config.rows) {
             for (x in 0 until config.cols) {
                 val face = tiling.faces[index++]
-                val verts = mutableSetOf<String>()
-                var e = face.any
-                do {
-                    val key = e.origin.key
-                    verts.add("${key.x}_${key.y}")
-                    e = e.next
-                } while (e !== face.any)
-                board.addCell(Cell(id = "${x}_${y}", vertices = verts))
+                board.addCell(face.toCell("${x}_${y}"))
             }
         }
     }


### PR DESCRIPTION
## Summary
- convert DCEL faces to board cells via `Face.toCell`
- use the helper when building the game board

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68806b7428808324a6ea362f458fba5a