### PR TITLE
Fix grid size restrictions

### DIFF
--- a/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
@@ -765,14 +765,14 @@ private fun SettingsDialog(
                     ConfigNumberField(
                         label = "Rows",
                         value = tempConfig.rows,
-                        onValueChange = { tempConfig = tempConfig.copy(rows = it.coerceIn(5, 20)) },
+                        onValueChange = { tempConfig = tempConfig.copy(rows = it) },
                         modifier = Modifier.weight(1f)
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                     ConfigNumberField(
                         label = "Cols",
                         value = tempConfig.cols,
-                        onValueChange = { tempConfig = tempConfig.copy(cols = it.coerceIn(5, 20)) },
+                        onValueChange = { tempConfig = tempConfig.copy(cols = it) },
                         modifier = Modifier.weight(1f)
                     )
                 }
@@ -838,7 +838,11 @@ private fun SettingsDialog(
         confirmButton = {
             TextButton(
                 onClick = {
-                    onConfigChange(tempConfig)
+                    val clamped = tempConfig.copy(
+                        rows = tempConfig.rows.coerceIn(5, 100),
+                        cols = tempConfig.cols.coerceIn(5, 100)
+                    )
+                    onConfigChange(clamped)
                     onDismiss()
                 }
             ) {


### PR DESCRIPTION
## Summary
- let users type any number of rows/columns
- clamp rows/cols to 5..100 when applying settings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6880702498cc8324a10bba995c0d0749