### PR TITLE
Update touch defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ You can also open the project in Android Studio and run it directly from the IDE
 
 ### Touch Controls
 
-By default you reveal a tile with a single tap and flag it with a double tap.
-Triple tap cycles marks on a tile. Long press does nothing.
+By default a single tap marks a tile with a question mark and a double tap flags it.
+Triple tap reveals the tile. Long press does nothing.
 
 ### Selecting a Grid Type
 

--- a/app/src/main/java/com/edgefield/minesweeper/PrefsManager.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/PrefsManager.kt
@@ -25,9 +25,9 @@ object PrefsManager {
         val gridTypeName = prefs.getString("gridType", GridType.SQUARE.name) ?: GridType.SQUARE.name
         val gridType = GridType.valueOf(gridTypeName)
         val edgeMode = prefs.getBoolean("edgeMode", true)
-        val singleTap = prefs.getString("singleTap", TouchAction.REVEAL.name) ?: TouchAction.REVEAL.name
+        val singleTap = prefs.getString("singleTap", TouchAction.QUESTION.name) ?: TouchAction.QUESTION.name
         val doubleTap = prefs.getString("doubleTap", TouchAction.FLAG.name) ?: TouchAction.FLAG.name
-        val tripleTap = prefs.getString("tripleTap", TouchAction.MARK_CYCLE.name) ?: TouchAction.MARK_CYCLE.name
+        val tripleTap = prefs.getString("tripleTap", TouchAction.REVEAL.name) ?: TouchAction.REVEAL.name
         val longPress = prefs.getString("longPress", TouchAction.NONE.name) ?: TouchAction.NONE.name
         val touchConfig = TouchConfig(
             singleTap = TouchAction.valueOf(singleTap),

--- a/app/src/main/java/com/edgefield/minesweeper/TileModels.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/TileModels.kt
@@ -27,9 +27,9 @@ enum class TouchAction {
 }
 
 data class TouchConfig(
-    val singleTap: TouchAction = TouchAction.REVEAL,
+    val singleTap: TouchAction = TouchAction.QUESTION,
     val doubleTap: TouchAction = TouchAction.FLAG,
-    val tripleTap: TouchAction = TouchAction.MARK_CYCLE,
+    val tripleTap: TouchAction = TouchAction.REVEAL,
     val longPress: TouchAction = TouchAction.NONE
 )
 


### PR DESCRIPTION
## Summary
- change the default actions in `TouchConfig`
- adjust fallback prefs for touch actions
- update the README touch controls section

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68811935dee88324a79c8a8d4fe61b77