### PR TITLE
Implement separate mark action

### DIFF
--- a/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameScreen.kt
@@ -32,6 +32,9 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.runtime.rememberCoroutineScope
 import android.view.ViewConfiguration
+import android.graphics.Paint
+import android.graphics.Typeface
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.zIndex
 import com.edgefield.minesweeper.graph.Cell
 import kotlinx.coroutines.delay
@@ -628,6 +631,7 @@ private fun GameBoard(vm: GameViewModel, tileSize: androidx.compose.ui.unit.Dp) 
 private fun getCellColor(cell: Cell, adj: Int, gameState: GameState): Color {
     return when {
         !cell.isRevealed && cell.isFlagged -> Color(0xFF64B5F6) // Darker blue water for flagged cells
+        !cell.isRevealed && cell.isMarked -> Color(0xFFFFF176) // Yellow for marked cells
         !cell.isRevealed -> Color(0xFF9E9E9E) // Gray for unrevealed
         cell.isMine && gameState == GameState.LOST -> Color(0xFFF44336) // Red for mines
         cell.isRevealed && adj == 0 -> Color(0xFFFFF9C4) // Sand for empty island
@@ -671,6 +675,14 @@ private fun DrawScope.drawTileOverlays(
             drawLine(Color(0xFF4CAF50).ghostly(ghost), start, mid, strokeWidth = stroke)
             drawLine(Color(0xFF4CAF50).ghostly(ghost), mid, end, strokeWidth = stroke)
         }
+    } else if (!cell.isRevealed && cell.isMarked) {
+        val paint = Paint().apply {
+            color = Color.Black.toArgb()
+            textAlign = Paint.Align.CENTER
+            textSize = tileSizePx * 0.5f
+            typeface = Typeface.DEFAULT_BOLD
+        }
+        drawContext.canvas.nativeCanvas.drawText("?", center.x, center.y + paint.textSize / 3f, paint)
     }
 }
 

--- a/app/src/main/java/com/edgefield/minesweeper/GameStateModels.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameStateModels.kt
@@ -5,7 +5,8 @@ data class CellState(
     val id: String,
     val isMine: Boolean,
     val isRevealed: Boolean,
-    val isFlagged: Boolean
+    val isFlagged: Boolean,
+    val isMarked: Boolean
 )
 
 data class EngineState(

--- a/app/src/main/java/com/edgefield/minesweeper/GameViewModel.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/GameViewModel.kt
@@ -71,7 +71,9 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
         } else {
             when (action) {
                 TouchAction.REVEAL -> reveal(boardCell)
-                TouchAction.FLAG, TouchAction.QUESTION, TouchAction.MARK_CYCLE -> toggleFlag(boardCell)
+                TouchAction.FLAG -> toggleFlag(boardCell)
+                TouchAction.QUESTION -> toggleMark(boardCell)
+                TouchAction.MARK_CYCLE -> cycleMark(boardCell)
                 TouchAction.NONE -> { /* Do nothing */ }
             }
         }
@@ -84,8 +86,19 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
 
     private fun toggleFlag(cell: Cell) {
         engine.board.getCell(cell.id)?.let { boardCell ->
-            val newFlag = !boardCell.isFlagged
-            engine.toggleMark(boardCell, newFlag)
+            engine.toggleFlag(boardCell)
+        }
+    }
+
+    private fun toggleMark(cell: Cell) {
+        engine.board.getCell(cell.id)?.let { boardCell ->
+            engine.toggleMark(boardCell)
+        }
+    }
+
+    private fun cycleMark(cell: Cell) {
+        engine.board.getCell(cell.id)?.let { boardCell ->
+            engine.cycleMark(boardCell)
         }
     }
     
@@ -152,7 +165,8 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
                 vertices = cell.vertices.toSet(),
                 isMine = cell.isMine,
                 isRevealed = cell.isRevealed,
-                isFlagged = cell.isFlagged
+                isFlagged = cell.isFlagged,
+                isMarked = cell.isMarked
             )
             copy.addCell(newCell)
         }

--- a/app/src/main/java/com/edgefield/minesweeper/PrefsManager.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/PrefsManager.kt
@@ -115,7 +115,8 @@ object PrefsManager {
                 cell.id,
                 if (cell.isMine) "1" else "0",
                 if (cell.isRevealed) "1" else "0",
-                if (cell.isFlagged) "1" else "0"
+                if (cell.isFlagged) "1" else "0",
+                if (cell.isMarked) "1" else "0"
             ).joinToString(",")
         }
     }
@@ -128,7 +129,8 @@ object PrefsManager {
                 id = parts[0],
                 isMine = parts.getOrNull(1) == "1",
                 isRevealed = parts.getOrNull(2) == "1",
-                isFlagged = parts.getOrNull(3) == "1"
+                isFlagged = parts.getOrNull(3) == "1",
+                isMarked = parts.getOrNull(4) == "1"
             )
         }
     }

--- a/app/src/main/java/com/edgefield/minesweeper/graph/Cell.kt
+++ b/app/src/main/java/com/edgefield/minesweeper/graph/Cell.kt
@@ -9,6 +9,7 @@ data class Cell(
     var isMine: Boolean = false,
     var isRevealed: Boolean = false,
     var isFlagged: Boolean = false,
+    var isMarked: Boolean = false,
     val neighbors: MutableSet<String> = mutableSetOf()
 )
 


### PR DESCRIPTION
## Summary
- add `isMarked` property to `Cell`
- update `GameEngine` with new mark helpers
- persist mark state in `PrefsManager`
- draw question marks on marked cells
- handle mark and flag gestures separately in `GameViewModel`

## Testing
- `gradle` tests are skipped per instructions

------
https://chatgpt.com/codex/tasks/task_e_688128c661ec83248ee4502b5434cd60